### PR TITLE
Replace "console_log" with "jsdebug"

### DIFF
--- a/tests/t7.idr
+++ b/tests/t7.idr
@@ -13,4 +13,4 @@ mutual
 
 main : JSIO ()
 main = do
-  console_log $ show $ is_even 10
+  jsdebug $ show $ is_even 10


### PR DESCRIPTION
This fixes the following error when compiling the tests:

```
compiling tests/t7.idr
./tests/t7.idr:15:6:When checking right hand side of main with expected type
        JSIO ()

No such variable console_log
```
