### PR TITLE
20190121 dom schedule isolate

### DIFF
--- a/Js/Html.idr
+++ b/Js/Html.idr
@@ -20,12 +20,18 @@ public export
 InputAttribute : Type -> Type
 InputAttribute a = Attribute 'InputAttribute a
 
+public export
+KeyEvtAttribute : Type -> Type
+KeyEvtAttribute a = Attribute 'KeyEvtAttribute a
+
 export
 implementation HtmlAllAttribute 'HtmlAttribute where
 
 export
-implementation  HtmlAllAttribute 'InputAttribute where
+implementation HtmlAllAttribute 'InputAttribute where
 
+export
+implementation HtmlAllAttribute 'KeyEvtAttribute where
 
 -------- Nodes --------
 
@@ -76,6 +82,11 @@ export
 cssClass : HtmlAllAttribute o => String -> Attribute o a
 cssClass s = stringAttribute "class" s
 
+export
+tabindex : HtmlAllAttribute o => Int -> Attribute o a
+tabindex idx = stringAttribute "tabindex" (show idx)
+
+
 -------- Events --------
 
 export
@@ -96,3 +107,56 @@ onlongpress x = customEventListenerAttribute "longpress" (jscall "$JSLIB$html.ad
 export
 onshortpress : HtmlAllAttribute o => a -> Attribute o a
 onshortpress x = customEventListenerAttribute "shortpress" (jscall "$JSLIB$html.addShortPressEventListener(%0)" (Ptr -> JS_IO ())) (\_ => pure x)
+
+public export
+record KeyEvent where
+  constructor MkKeyEvent
+  altKey : Bool
+  char : String
+  code : String
+  ctrlKey : Bool
+  isComposing : Bool
+  key : String
+  keyCode : Int
+  locale : String
+  location : Int
+  metaKey : Bool
+  repeat : Bool
+  shiftKey : Bool  
+
+keyRecordOfEvent : Ptr -> JS_IO KeyEvent
+keyRecordOfEvent x =
+  do
+    altKey <- jscall "%0.altKey" (Ptr -> JS_IO Int) x
+    char <- jscall "%0.char" (Ptr -> JS_IO String) x
+    code <- jscall "%0.code" (Ptr -> JS_IO String) x
+    ctrlKey <- jscall "%0.ctrlKey" (Ptr -> JS_IO Int) x
+    isComposing <- jscall "%0.isComposing" (Ptr -> JS_IO Int) x
+    key <- jscall "%0.key" (Ptr -> JS_IO String) x
+    keyCode <- jscall "%0.keyCode" (Ptr -> JS_IO Int) x
+    locale <- jscall "%0.locale" (Ptr -> JS_IO String) x
+    location <- jscall "%0.location" (Ptr -> JS_IO Int) x
+    metaKey <- jscall "%0.metaKey" (Ptr -> JS_IO Int) x
+    repeat <- jscall "%0.repeat" (Ptr -> JS_IO Int) x
+    shiftKey <- jscall "%0.shiftKey" (Ptr -> JS_IO Int) x
+    pure (MkKeyEvent (altKey /= 0) char code (ctrlKey /= 0) (isComposing /= 0) key keyCode locale location (metaKey /= 0) (repeat /= 0) (shiftKey /= 0))
+
+export
+onkeydown : HtmlAllAttribute o => (KeyEvent -> a) -> Attribute o a
+onkeydown convert = 
+  eventListenerAttribute "keydown" 
+  (\x =>
+    do
+      evt <- keyRecordOfEvent x
+      pure (convert evt)
+  )
+
+export
+onkeyup : HtmlAllAttribute o => (KeyEvent -> a) -> Attribute o a
+onkeyup convert = 
+  eventListenerAttribute "keyup"
+  (\x =>
+    do
+      evt <- keyRecordOfEvent x
+      pure (convert evt)
+  )

--- a/examples/compileAll.sh
+++ b/examples/compileAll.sh
@@ -3,3 +3,4 @@ export IDRISJS_DEBUG=$2
 idris --codegen javascript -p contrib -p js ex0.idr -o ex0.html
 idris --codegen javascript -p contrib -p js ex1.idr -o ex1.html
 idris --codegen javascript -p contrib -p js todo.idr -o todo.html
+idris --codegen javascript -p contrib -p js -p containers game.idr -o game.html

--- a/examples/game.idr
+++ b/examples/game.idr
@@ -1,0 +1,150 @@
+
+module Main
+
+import Js.Dom
+import public Js.ASync
+import Control.ST
+import Js.HtmlStyle
+import Data.AVL.Set
+
+data Input 
+  = Tick
+  | KeyDown String
+  | KeyUp String
+
+record Model where
+  constructor MkModel
+  scroll : List String
+  n : Int
+  keymap : Set String
+  hero : (Double, Double)
+
+emptyModel : Model
+emptyModel =
+  MkModel
+    ["ola"]
+    0
+    Data.AVL.Set.empty
+    (320,240)
+
+add_scroll : String -> Model -> Model
+add_scroll s model =
+  let
+    lines = scroll model
+  in
+  set_scroll (s :: lines) model
+
+record Circle where
+  constructor MkCircle
+  center_x : Double
+  center_y : Double
+  radius : Double
+  color : String
+
+Gui : Dom m => Type
+Gui {m} = DomRef {m} () (const Model) (const Input) ()
+
+interface Drawable a where
+  draw : a -> Html Input
+  
+implementation Drawable Circle where
+  draw c =
+    div
+      [ style 
+          [ position (Fixed (center_x c) (center_y c))
+          , width (2.0 * (radius c))
+          , height (2.0 * (radius c))
+          , backgroundColor (color c)
+          ]
+      ] []
+      
+drawables : Model -> List (Html Input)
+drawables model =
+  let
+    (hx,hy) = hero model
+  in
+  [ draw (MkCircle hx hy 5.0 "red") ]
+
+vw : () -> Model -> Html Input
+vw () inp = 
+  div 
+    [ style 
+        [ position (Fixed 0 0)
+        , width 640
+        , height 480
+        ] 
+    , onkeydown (\k => KeyDown (key k))
+    , onkeyup (\k => KeyUp (key k))
+    , tabindex 0
+    ]
+    ([ div [] (map (\t => div [] [text t]) (scroll inp))
+     ] ++ (drawables inp)
+    )
+
+handleKeys : Model -> Model
+handleKeys model =
+  let
+    (hx,hy) = hero model 
+    km = keymap model
+  in
+  if Data.AVL.Set.contains "a" km then
+    set_hero (hx - 3, hy) model
+  else if Data.AVL.Set.contains "s" km then
+    set_hero (hx, hy + 3) model
+  else if Data.AVL.Set.contains "d" km then
+    set_hero (hx + 3, hy) model
+  else if Data.AVL.Set.contains "w" km then
+    set_hero (hx, hy - 3) model
+  else
+    model
+
+handleInput : Dom m => (d: Var) -> (s: Var) -> Input -> ST m () [s:::State Model, d:::Gui {m}]
+handleInput d s x =
+  case x of
+    KeyDown k =>
+      do
+        inp <- read s
+        let km = keymap inp
+        write s (add_scroll ("down " ++ k) (set_keymap (Data.AVL.Set.insert k km) inp))
+        
+    KeyUp k =>
+      do
+        inp <- read s
+        let km = keymap inp
+        let turnoff = Data.AVL.Set.fromList [ k ]
+        write s (add_scroll ("up " ++ k) (set_keymap (Data.AVL.Set.difference km turnoff) inp))
+        
+    Tick => 
+      do
+        inp <- read s
+        write s (handleKeys (set_n ((n inp) + 1) inp))
+        call $ schedule d 30 Tick
+        call $ domPut d inp
+
+pageLoop : Dom m => (d: Var) -> (s:Var) -> ST m () [s:::State Model, d:::Gui {m}]
+pageLoop d s =
+  do
+    x <- call $ getInput d
+
+    handleInput d s x
+
+    pageLoop d s
+    
+pageStart : Dom m => (d: Var) -> (s:Var) -> ST m () [s:::State Model, d:::Gui {m}]
+pageStart d s =
+  do
+    call $ schedule d 30 Tick
+    pageLoop d s
+
+page : Dom m => ST m () []
+page =
+  do
+    let model = emptyModel
+    dom <- initBody [] vw () model
+    txt <- new model
+    pageStart dom txt
+    delete txt
+    clearDom dom
+
+main : JS_IO ()
+main = setASync_ $ run page


### PR DESCRIPTION
I've been tinkering with idrisjs and added some things I think weren't easy to do before.  Thanks for making idrisjs ... I've wanted to do some more practical things with idris, and I think that with some polishing, it gives bucklescript-tea and the elm html library some competition.

I've isolated a couple basic improvements here to allow some simple interactivity.  Since I'm trying to ensure that these changes are well isolated, I've got just two here and some code to exercise them:

1) I wasn't able to figure out definitely whether this was possible in another way, so I added a schedule method to dom that allows one to set a message to be sent in the near future.

Used like ```call $ schedule d 30 Tick```, in the dom, It'll post back a message you specify after real time passes.  If there's already a better way of doing this, then I think I misunderstood it.

2) Add keydown and keyup message handlers in Html.

I can add more stuff systematically with the goal of covering the full dom spec if you're favorable to these kinds of changes.  I have some things in elm and fable-elmish that would make interesting candidates to port to identify places where idrisjs lacks capability.

The following shows where I'm going with some of this, as a kind of proof of concept game in idris (not a good game, but it has a goal and a way to achieve it) 

(note there are a lot of small changes in idrisjs to make this go).

https://github.com/prozacchiwawa/idrisjs/blob/20190119-add-capability/examples/game.idr